### PR TITLE
Use sbtscala image for github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,11 @@ on:
 jobs:
   openjdk21:
     runs-on: ubuntu-latest
-    env:
-      JAVA_OPTS: "-Xmx6G -XX:+UseG1GC"
-      SBT_OPTS: "-Dsbt.ci=true"
+    container: sbtscala/scala-sbt:eclipse-temurin-jammy-21.0.1_12_1.9.7_3.3.1
     steps:
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
-
-      - name: Setup JVM
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: sbt
+        uses: actions/checkout@v4
 
       - name: Compile
         run: sbt compile


### PR DESCRIPTION
(for v3 branch - #247)

Currently unable to run the tests in my local environment because I'm already in a Docker container.

This allows for using [act](https://github.com/nektos/act) for running the Github action locally.