### PR TITLE
Allow custom application.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bloop/
 .metals/
+.vscode/
 logs/
 project/metals.sbt
 project/project/
@@ -7,3 +8,5 @@ target/
 RUNNING_PID
 # docker sbt
 /?
+
+app/src/main/resources/application.conf

--- a/app/src/main/resources/application.conf.default
+++ b/app/src/main/resources/application.conf.default
@@ -1,0 +1,3 @@
+include "base"
+
+# override additional values from base.conf here

--- a/app/src/main/resources/base.conf
+++ b/app/src/main/resources/base.conf
@@ -3,7 +3,7 @@ kamon {
   metric.tick-interval = 60 seconds
   influxdb {
     authentication {
-      token = "NCnPKbCqXinm46K86lVfIhwXD1_BaJaRaftNeqNWB6-34X2YUMNbZT6DnT3RtJgnFoaY7lyRrO_NGJFAteRP2g=="
+      token = ""
     }
     hostname = "127.0.0.1"
     port = 8086


### PR DESCRIPTION
Because of `run / fork := true`, seems it's not possible to set properties when running `sbt app/run`:

```bash
sbt -Dkamon.influxdb.hostname=influxdb app/run   # <--- this does not work. config value not changed.
```

This PR takes the approach used by the lila repo to have a custom `application.conf` which is gitignored that extends `base.conf` and overrides values.