### PR TITLE
Allow Kamon config to read from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Start with default config:
 sbt app/run
 ```
 
-Use environment variables to start with custom config (`redis.host` for example):
+Use environment variables to start with custom config (`redis.host` and `kamon` for example):
 ```sh
-REDIS_HOST=redis sbt app/run
+REDIS_HOST=redis KAMON_ENABLED=true CONFIG_FORCE_kamon_influxdb_port=8888 sbt app/run
 ```
 
 For other `config` check [AppConfig.scala](https://github.com/lichess-org/lila-fishnet/blob/master/app/src/main/scala/AppConfig.scala)

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ inThisBuild(
     scalaVersion  := "3.3.1",
     versionScheme := Some("early-semver"),
     version       := "3.0",
-    run / fork    := true
+    run / fork    := true,
+    run / javaOptions += "-Dconfig.override_with_env_vars=true"
   )
 )
 
@@ -41,12 +42,11 @@ lazy val app = project
       testContainers,
       log4CatsNoop,
       http4sClient,
-      catsEffectTestKit,
+      catsEffectTestKit
     ),
-    javaAgents += kamonAgent,
+    javaAgents += kamonAgent
   )
   .enablePlugins(JavaAppPackaging, JavaAgent)
-
 
 lazy val root = project
   .in(file("."))


### PR DESCRIPTION
Because of `run/fork:=true`, We can set system properties when execute `sbt app/run`. So, we need a way to Kamon's config to read from environment variables. Which is enabled by setting `-Dconfig.override_with_env_vars=true` in `run` option.

More info here:
https://github.com/lightbend/config#optional-system-or-env-variable-overrides