### PR TITLE
Simplify ApiErrorLogger.instance

### DIFF
--- a/app/src/main/scala/http/ApiLogger.scala
+++ b/app/src/main/scala/http/ApiLogger.scala
@@ -5,20 +5,18 @@ import cats.data.Kleisli
 import cats.syntax.all.*
 import cats.effect.IO
 import org.http4s.internal.Logger as Http4sLogger
-import org.http4s.{ HttpApp, Response }
+import org.http4s.{ HttpApp, Request, Response }
 import org.typelevel.log4cats.Logger
 
 object ApiErrorLogger:
 
-  val logOnError: Response[IO] => Boolean = res => !res.status.isSuccess && res.status.code != 404
+  val isResponseError: Response[IO] => Boolean = res => !res.status.isSuccess && res.status.code != 404
+
+  private def logError(req: Request[IO], res: Response[IO])(using Logger[IO]): IO[Unit] =
+    Http4sLogger.logMessage(req)(true, true)(Logger[IO].warn) >>
+      Http4sLogger.logMessage(res)(true, true)(Logger[IO].warn)
 
   def instance(using Logger[IO]): HttpApp[IO] => HttpApp[IO] = http =>
     Kleisli: req =>
       http(req).flatTap: res =>
-        logOnError(res)
-          .pure[IO]
-          .ifM(
-            Http4sLogger.logMessage(req)(true, true)(Logger[IO].warn) >>
-              Http4sLogger.logMessage(res)(true, true)(Logger[IO].warn),
-            IO.unit
-          )
+        logError(req, res).whenA(isResponseError(res))


### PR DESCRIPTION
Aim of this PR is to simplify `ApiErrorLogger.instance` by replacing  `..pure[IO].ifM..` with just a `whenA`. Both `ifM` and `whenA` takes effect by name, so no penalty for `whenA` usage over `ifM`.

I also extracted logger calls into a separate function, so that `ApiErrorLogger.instance` shortens to:

~~~scala
def instance(using Logger[IO]): HttpApp[IO] => HttpApp[IO] = http =>
  Kleisli: req =>
    http(req).flatTap: res =>
      logError(req, res).whenA(isResponseError(res))
~~~

I hope this change simplifies the code so it is easier to maintain. Looking for CI tests, because of my inability to running tests locally