### PR TITLE
Simplify Executor.acquire

### DIFF
--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -43,10 +43,8 @@ object Executor:
               ref.modify: coll =>
                 coll.values
                   .filter(_.nonAcquired)
-                  .foldLeft[Option[Work.Move]](none):
-                    case (found, m) =>
-                      Some(found.fold(m): a =>
-                        if m.canAcquire(key) && m.createdAt.isBefore(a.createdAt) then m else a)
+                  .reduceLeftOption: (a, m) =>
+                    if m.canAcquire(key) && m.createdAt.isBefore(a.createdAt) then m else a
                   .map: m =>
                     val move = m.assignTo(key, at)
                     (coll + (move.id -> move)) -> move.toRequestWithId.some

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -43,8 +43,7 @@ object Executor:
               ref.modify: coll =>
                 coll.values
                   .filter(_.nonAcquired)
-                  .reduceLeftOption: (a, m) =>
-                    if m.canAcquire(key) && m.createdAt.isBefore(a.createdAt) then m else a
+                  .minByOption(_.createdAt)
                   .map: m =>
                     val move = m.assignTo(key, at)
                     (coll + (move.id -> move)) -> move.toRequestWithId.some

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -42,11 +42,11 @@ object Executor:
             IO.realTimeInstant.flatMap: at =>
               ref.modify: coll =>
                 coll.values
+                  .filter(_.nonAcquired)
                   .foldLeft[Option[Work.Move]](none):
-                    case (found, m) if m.nonAcquired =>
+                    case (found, m) =>
                       Some(found.fold(m): a =>
                         if m.canAcquire(key) && m.createdAt.isBefore(a.createdAt) then m else a)
-                    case (found, _) => found
                   .map: m =>
                     val move = m.assignTo(key, at)
                     (coll + (move.id -> move)) -> move.toRequestWithId.some

--- a/app/src/main/scala/Work.scala
+++ b/app/src/main/scala/Work.scala
@@ -33,7 +33,6 @@ object Work:
     def isAcquiredBy(clientKey: ClientKey) = acquiredByKey contains clientKey
     def isAcquired                         = acquired.isDefined
     def nonAcquired                        = !isAcquired
-    def canAcquire(clientKey: ClientKey)   = acquired.fold(true)(_.clientKey != clientKey)
     def acquiredBefore(date: Instant)      = acquiredAt.fold(false)(_.isBefore(date))
 
     def assignTo(clientKey: ClientKey, at: Instant) =


### PR DESCRIPTION
Same aim as in #266.

First, I extracted filtering logic from pattern match by applying `filter` method before, which also simplified pattern match to 1 case arm. Next I replaced `foldLeft[Option]` by `reduceLeftOption`, a little cleaner, but logic exact the same. And finally, I noticed that after filtering works with `_.nonAcquired`, the `m.canAcquire(key)` part of if-statement inside always evaluates to `true` because of the `Work.Move` implementation:

https://github.com/Masynchin/lila-fishnet/blob/2135cb36973495e55bc8909710063e7f388959e5/app/src/main/scala/Work.scala#L34-L36

So, `reduce`'s if-statement shortens to `m.createdAt.isBefore(a.createdAt)`, which is just comparing who created earliest. Only thing I don't know what is the logic when two `Move`'s `createdAt` equals, or can it be at all