### PR TITLE
Use default executor constructor where possible

### DIFF
--- a/app/src/test/scala/ExecutorTest.scala
+++ b/app/src/test/scala/ExecutorTest.scala
@@ -166,7 +166,7 @@ object ExecutorTest extends SimpleIOSuite:
     yield assert(acquired.isDefined && empty.isEmpty)
 
   def createExecutor(config: ExecutorConfig = ExecutorConfig(300)): IO[Executor] =
-    createLilaClient.flatMap(createExecutor(_)(config))
+    createLilaClient.flatMap(ioExecutor(_)(noopMonitor, config))
 
   def createExecutor(ref: Ref[IO, List[Lila.Move]])(config: ExecutorConfig): IO[Executor] =
     ioExecutor(createLilaClient(ref))(noopMonitor, config)

--- a/app/src/test/scala/ExecutorTest.scala
+++ b/app/src/test/scala/ExecutorTest.scala
@@ -109,9 +109,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("after post an invalid move, acquire again should return work.some"):
     for
-      ref <- Ref.of[IO, List[Lila.Move]](Nil)
-      client = createLilaClient(ref)
-      executor <- ioExecutor(client)(noopMonitor, ExecutorConfig(2))
+      executor <- createExecutor(ExecutorConfig(2))
       _        <- executor.add(request)
       acquired <- executor.acquire(key)
       workId = acquired.get.id
@@ -122,9 +120,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("should not give up after 2 tries"):
     for
-      ref <- Ref.of[IO, List[Lila.Move]](Nil)
-      client = createLilaClient(ref)
-      executor <- ioExecutor(client)(noopMonitor, ExecutorConfig(2))
+      executor <- createExecutor(ExecutorConfig(2))
       _        <- executor.add(request)
       _ <- (executor.acquire(key).flatMap(x => executor.move(x.get.id, key, invalidMove))).replicateA_(2)
       acquired <- executor.acquire(key)
@@ -132,9 +128,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("should give up after 3 tries"):
     for
-      ref <- Ref.of[IO, List[Lila.Move]](Nil)
-      client = createLilaClient(ref)
-      executor <- ioExecutor(client)(noopMonitor, ExecutorConfig(2))
+      executor <- createExecutor(ExecutorConfig(2))
       _        <- executor.add(request)
       _ <- (executor.acquire(key).flatMap(x => executor.move(x.get.id, key, invalidMove))).replicateA_(3)
       acquired <- executor.acquire(key)
@@ -142,9 +136,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("give up due to invalid move should reduce task's size"):
     for
-      ref <- Ref.of[IO, List[Lila.Move]](Nil)
-      client = createLilaClient(ref)
-      executor <- ioExecutor(client)(noopMonitor, ExecutorConfig(2))
+      executor <- createExecutor(ExecutorConfig(2))
       _        <- executor.add(request)
       _        <- executor.add(request.copy(id = GameId("2")))
       _  <- (executor.acquire(key).flatMap(x => executor.move(x.get.id, key, invalidMove))).replicateA_(3)
@@ -155,9 +147,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("give up due to cleaning should reduce task's size"):
     for
-      ref <- Ref.of[IO, List[Lila.Move]](Nil)
-      client = createLilaClient(ref)
-      executor <- ioExecutor(client)(noopMonitor, ExecutorConfig(2))
+      executor <- createExecutor(ExecutorConfig(2))
       _        <- executor.add(request)
       _        <- executor.add(request.copy(id = GameId("2")))
       _  <- (executor.acquire(key).flatMap(x => executor.move(x.get.id, key, invalidMove))).replicateA_(2)

--- a/app/src/test/scala/ExecutorTest.scala
+++ b/app/src/test/scala/ExecutorTest.scala
@@ -62,7 +62,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("post move after acquire should send move"):
     for
-      ref      <- Ref.of[IO, List[Lila.Move]](Nil)
+      ref      <- emptyMovesRef
       executor <- createExecutor(ref)(ExecutorConfig(2))
       _        <- executor.add(request)
       acquired <- executor.acquire(key)
@@ -72,7 +72,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("post move after timeout should not send move"):
     for
-      ref      <- Ref.of[IO, List[Lila.Move]](Nil)
+      ref      <- emptyMovesRef
       executor <- createExecutor(ref)(ExecutorConfig(2))
       _        <- executor.add(request)
       acquired <- executor.acquire(key)
@@ -83,7 +83,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("after timeout move should be able to acquired again"):
     for
-      ref      <- Ref.of[IO, List[Lila.Move]](Nil)
+      ref      <- emptyMovesRef
       executor <- createExecutor(ref)(ExecutorConfig(2))
       _        <- executor.add(request)
       _        <- executor.acquire(key)
@@ -95,7 +95,7 @@ object ExecutorTest extends SimpleIOSuite:
 
   test("post an invalid move should not send move"):
     for
-      ref      <- Ref.of[IO, List[Lila.Move]](Nil)
+      ref      <- emptyMovesRef
       executor <- createExecutor(ref)(ExecutorConfig(2))
       _        <- executor.add(request)
       acquired <- executor.acquire(key)
@@ -177,11 +177,12 @@ object ExecutorTest extends SimpleIOSuite:
       .map(Executor.instance(_, client, monitor, config))
 
   def createLilaClient: IO[LilaClient] =
-    Ref
-      .of[IO, List[Lila.Move]](Nil)
-      .map(createLilaClient)
+    emptyMovesRef.map(createLilaClient)
 
   def createLilaClient(ref: Ref[IO, List[Lila.Move]]): LilaClient =
     new LilaClient:
       def send(move: Lila.Move): IO[Unit] =
         ref.update(_ :+ move)
+
+  def emptyMovesRef: IO[Ref[IO, List[Lila.Move]]] =
+    Ref.of[IO, List[Lila.Move]](Nil)


### PR DESCRIPTION
In tests where `ref` not used (which is half of all tests) I have replaced it with `createExecutor()` where executor parameters set to defaults, and `createExecutor(n)` where `n` is not equals to default `300`