### PR TITLE
Use mapAccumulateFilter

### DIFF
--- a/app/src/main/scala/AppState.scala
+++ b/app/src/main/scala/AppState.scala
@@ -48,11 +48,12 @@ object AppState:
         case Some(task)                           => GetTaskResult.AcquiredByOther(task)
 
     def updateOrGiveUp(candidates: List[Work.Task]): (AppState, List[Work.Task]) =
-      candidates.foldLeft(state -> Nil) { case ((state, xs), task) =>
-        task.clearAssignedKey match
-          case None                 => (state - task.id, task :: xs)
-          case Some(unAssignedTask) => (state.updated(task.id, unAssignedTask), xs)
-      }
+      candidates.mapAccumulateFilter(state)(_.clearOrGiveUp(_))
+
+    def clearOrGiveUp(task: Work.Task): (AppState, Option[Work.Task]) =
+      task.clearAssignedKey match
+        case None                 => (state - task.id, Some(task))
+        case Some(unAssignedTask) => (state.updated(task.id, unAssignedTask), None)  
 
     def acquiredBefore(since: Instant): List[Work.Task] =
       state.values.filter(_.acquiredBefore(since)).toList


### PR DESCRIPTION
This is PR in advance, because it relies on adding `mapAccumulateFilter` to `cats` (https://github.com/typelevel/cats/pull/4561).

Besides that I have replaced `foldLeft` in `updateOrGiveUp` with `mapAccumulateFilter`, I have also added new `clearOrGiveUp` method to `AppState` and use it in `Executor.move`.

I want to denote two things I have observed:

1) Is `state.updated(task.id, unAssignedTask)` same as `state.add(updated)`? It seems yes for me, but I am not sure.
2) `clearOrGiveUp` naming. I have bad intuition in the semantics of the project, so I would be happy if you choose better name for this method.