### PR TITLE
Add unassignOrGiveUp

### DIFF
--- a/app/src/main/scala/AppState.scala
+++ b/app/src/main/scala/AppState.scala
@@ -47,7 +47,7 @@ object AppState:
         case Some(task) if task.isAcquiredBy(key) => GetTaskResult.Found(task)
         case Some(task)                           => GetTaskResult.AcquiredByOther(task)
 
-    def updateOrGiveUp(candidates: List[Work.Task]): (AppState, List[Work.Task]) =
+    def unassignOrGiveUp(candidates: List[Work.Task]): (AppState, List[Work.Task]) =
       candidates.foldLeft(state -> Nil) { case ((state, xs), task) =>
         val (newState, maybeGivenUp) = state.unassignOrGiveUp(task)
         (newState, maybeGivenUp.fold(xs)(_ :: xs))
@@ -56,7 +56,7 @@ object AppState:
     def unassignOrGiveUp(task: Work.Task): (AppState, Option[Work.Task]) =
       task.clearAssignedKey match
         case None                 => (state - task.id, Some(task))
-        case Some(unAssignedTask) => (state.updated(task.id, unAssignedTask), None)
+        case Some(unassignedTask) => (state.updated(task.id, unassignedTask), None)
 
     def acquiredBefore(since: Instant): List[Work.Task] =
       state.values.filter(_.acquiredBefore(since)).toList

--- a/app/src/main/scala/AppState.scala
+++ b/app/src/main/scala/AppState.scala
@@ -49,9 +49,8 @@ object AppState:
 
     def updateOrGiveUp(candidates: List[Work.Task]): (AppState, List[Work.Task]) =
       candidates.foldLeft(state -> Nil) { case ((state, xs), task) =>
-        task.clearAssignedKey match
-          case None                 => (state - task.id, task :: xs)
-          case Some(unAssignedTask) => (state.updated(task.id, unAssignedTask), xs)
+        val (newState, maybeGivenUp) = state.unassignOrGiveUp(task)
+        (newState, maybeGivenUp.fold(xs)(_ :: xs))
       }
 
     def unassignOrGiveUp(task: Work.Task): (AppState, Option[Work.Task]) =

--- a/app/src/main/scala/AppState.scala
+++ b/app/src/main/scala/AppState.scala
@@ -54,6 +54,11 @@ object AppState:
           case Some(unAssignedTask) => (state.updated(task.id, unAssignedTask), xs)
       }
 
+    def unassignOrGiveUp(task: Work.Task): (AppState, Option[Work.Task]) =
+      task.clearAssignedKey match
+        case None                 => (state - task.id, Some(task))
+        case Some(unAssignedTask) => (state.updated(task.id, unAssignedTask), None)
+
     def acquiredBefore(since: Instant): List[Work.Task] =
       state.values.filter(_.acquiredBefore(since)).toList
 

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -69,10 +69,10 @@ object Executor:
                     client.send(Lila.Response(task.request.id, task.request.moves, uci)))
                 case _ =>
                   val (newState, maybeGivenUp) = state.unassignOrGiveUp(task)
-                  val io = maybeGivenUp.traverse_(task =>
+                  val logs = maybeGivenUp.traverse_(task =>
                     Logger[IO].warn(s"Give up move due to invalid move $response by $key for $task")
-                  )
-                  newState -> io *> failure(task, key)
+                  ) *> failure(task, key)
+                  newState -> logs
 
       def clean(since: Instant): IO[Unit] =
         ref.flatModify: state =>

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -78,7 +78,7 @@ object Executor:
         ref.flatModify: state =>
           val timedOut                 = state.acquiredBefore(since)
           val timedOutLogs             = logTimedOut(state, timedOut)
-          val (newState, gavedUpMoves) = state.updateOrGiveUp(timedOut)
+          val (newState, gavedUpMoves) = state.unassignOrGiveUp(timedOut)
           newState -> timedOutLogs
             *> gavedUpMoves.traverse_(m => Logger[IO].warn(s"Give up move due to clean up: $m"))
             *> monitor.updateSize(newState)

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -69,9 +69,9 @@ object Executor:
                     client.send(Lila.Response(task.request.id, task.request.moves, uci)))
                 case _ =>
                   val (newState, maybeGivenUp) = state.unassignOrGiveUp(task)
-                  val io = maybeGivenUp.traverse_(task => Logger[IO].warn(
-                    s"Give up move due to invalid move $response by $key for $task"
-                  ))
+                  val io = maybeGivenUp.traverse_(task =>
+                    Logger[IO].warn(s"Give up move due to invalid move $response by $key for $task")
+                  )
                   newState -> io *> failure(task, key)
 
       def clean(since: Instant): IO[Unit] =

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -68,12 +68,10 @@ object Executor:
                   state.remove(task.id) -> (monitor.success(task) >>
                     client.send(Lila.Response(task.request.id, task.request.moves, uci)))
                 case _ =>
-                  val (newState, io) = task.clearAssignedKey match
-                    case None =>
-                      state.remove(workId) -> Logger[IO].warn(
-                        s"Give up move due to invalid move $response by $key for $task"
-                      )
-                    case Some(updated) => state.add(updated) -> IO.unit
+                  val (newState, maybeGivenUp) = state.unassignOrGiveUp(task)
+                  val io = maybeGivenUp.traverse_(task => Logger[IO].warn(
+                    s"Give up move due to invalid move $response by $key for $task"
+                  ))
                   newState -> io *> failure(task, key)
 
       def clean(since: Instant): IO[Unit] =

--- a/app/src/test/scala/AppStateTest.scala
+++ b/app/src/test/scala/AppStateTest.scala
@@ -71,30 +71,30 @@ class AppStateTest extends ScalaCheckSuite:
   test("updateOrGiveUp is a subset of given tasks"):
     forAll: (state: AppState, before: Instant) =>
       val candidates   = state.acquiredBefore(before)
-      val (_, givenUp) = state.updateOrGiveUp(candidates)
+      val (_, givenUp) = state.unassignOrGiveUp(candidates)
       givenUp.toSet.subsetOf(candidates.toSet)
 
   test("updateOrGiveUp preserves size"):
     forAll: (state: AppState, before: Instant) =>
       val candidates          = state.acquiredBefore(before)
-      val (newState, givenUp) = state.updateOrGiveUp(candidates)
+      val (newState, givenUp) = state.unassignOrGiveUp(candidates)
       newState.size + givenUp.size == state.size
 
   test("all given up tasks are outOfTries"):
     forAll: (state: AppState, before: Instant) =>
       val candidates   = state.acquiredBefore(before)
-      val (_, givenUp) = state.updateOrGiveUp(candidates)
+      val (_, givenUp) = state.unassignOrGiveUp(candidates)
       givenUp.forall(_.isOutOfTries)
 
   test("all candidates that are not given up are not outOfTries"):
     forAll: (state: AppState, before: Instant) =>
       val candidates   = state.acquiredBefore(before)
-      val (_, givenUp) = state.updateOrGiveUp(candidates)
+      val (_, givenUp) = state.unassignOrGiveUp(candidates)
       val rest         = candidates.filterNot(givenUp.contains)
       rest.forall(!_.isOutOfTries)
 
   test("after cleanup, acquiredBefore is empty"):
     forAll: (state: AppState, before: Instant) =>
       val candidates    = state.acquiredBefore(before)
-      val (newState, _) = state.updateOrGiveUp(candidates)
+      val (newState, _) = state.unassignOrGiveUp(candidates)
       newState.acquiredBefore(before).isEmpty

--- a/app/src/test/scala/AppStateTest.scala
+++ b/app/src/test/scala/AppStateTest.scala
@@ -9,8 +9,6 @@ import Arbitraries.given
 
 class AppStateTest extends ScalaCheckSuite:
 
-  override def scalaCheckInitialSeed = "lwfNzhdC038hCsaHpM4QBkFYs5eFtR9GLPHuzIE08KP="
-
   test("tasks.fromTasks == identity"):
     forAll: (state: AppState) =>
       assertEquals(AppState.fromTasks(state.tasks), state)


### PR DESCRIPTION
https://github.com/lichess-org/lila-fishnet/pull/287#issuecomment-1994603313 - done!

The only difference expect for naming, is the usage of `traverse_` instead of `traverse`.

Is there possibility and necessity to replace `state.updated` with `state.add`? Should be other methods be renamed?