### PR TITLE
Invalidate task if receive null bestmove from clients

### DIFF
--- a/app/src/main/scala/AppState.scala
+++ b/app/src/main/scala/AppState.scala
@@ -30,6 +30,9 @@ object AppState:
     inline def remove(id: WorkId): AppState =
       state - id
 
+    inline def get(id: WorkId): Option[Work.Task] =
+      state.get(id)
+
     inline def size: Int = state.size
 
     inline def count(p: Task => Boolean): Int = state.count(x => p(x._2))

--- a/app/src/main/scala/AppState.scala
+++ b/app/src/main/scala/AppState.scala
@@ -35,7 +35,7 @@ object AppState:
 
     inline def size: Int = state.size
 
-    inline def count(p: Task => Boolean): Int = state.count(x => p(x._2))
+    inline def count(p: Task => Boolean): Int = state.count((_, x) => p(x))
 
     def tryAcquire(key: ClientKey, at: Instant): (AppState, Option[Task]) =
       state.earliestNonAcquired

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -17,6 +17,7 @@ trait Executor:
   def acquire(accquire: ClientKey): IO[Option[Work.Task]]
   // fishnet client sends the best move for it's assigned task
   def move(workId: WorkId, fishnetKey: ClientKey, move: BestMove): IO[Unit]
+  def invalidate(workId: WorkId, fishnetKey: ClientKey): IO[Unit] = IO.unit
   // Lila sends a position
   def add(work: Lila.Request): IO[Unit]
   // clean up all works that are acquired before a given time

--- a/app/src/main/scala/Executor.scala
+++ b/app/src/main/scala/Executor.scala
@@ -13,15 +13,13 @@ import java.time.Instant
   *   - adding work to the queue
   */
 trait Executor:
-  // fishnet client tries to get an unassigned task
+  // Get an unassigned task from the queue
+  // If there is no unassigned task, return None
   def acquire(accquire: ClientKey): IO[Option[Work.Task]]
   // fishnet client sends the best move for it's assigned task
-  def move(workId: WorkId, fishnetKey: ClientKey, move: BestMove): IO[Unit]
-  // fishnet cannot find the best move
-  // so it either invalid moves or the game is already finished
-  // We may need to check if the task is really invalid
-  def invalidate(workId: WorkId, fishnetKey: ClientKey): IO[Unit]
-  // Lila sends a position
+  // move is none if it's assigned task is invalid or the game is already finished
+  def move(workId: WorkId, key: ClientKey, move: Option[BestMove]): IO[Unit]
+  // Receive a new work from Lila
   def add(work: Lila.Request): IO[Unit]
   // clean up all works that are acquired before a given time
   // this is to prevent tasks from being stuck in the queue
@@ -61,7 +59,10 @@ object Executor:
         IO.realTimeInstant.flatMap: at =>
           ref.modify(_.tryAcquire(key, at))
 
-      def move(workId: WorkId, key: ClientKey, response: BestMove): IO[Unit] =
+      def move(workId: WorkId, key: ClientKey, response: Option[BestMove]): IO[Unit] =
+        response.fold(invalidate(workId, key))(move(workId, key, _))
+
+      private def move(workId: WorkId, key: ClientKey, response: BestMove): IO[Unit] =
         ref.flatModify: state =>
           state(workId, key) match
             case GetTaskResult.NotFound              => state -> logNotFound(workId, key)
@@ -78,7 +79,7 @@ object Executor:
                   ) *> failure(task, key)
                   newState -> logs
 
-      def invalidate(workId: WorkId, key: ClientKey): IO[Unit] =
+      private def invalidate(workId: WorkId, key: ClientKey): IO[Unit] =
         ref.flatModify: state =>
           state.remove(workId) ->
             state

--- a/app/src/main/scala/http/FishnetRoutes.scala
+++ b/app/src/main/scala/http/FishnetRoutes.scala
@@ -24,8 +24,7 @@ final class FishnetRoutes(executor: Executor) extends Http4sDsl[IO]:
     case req @ POST -> Root / "move" / WorkIdVar(id) =>
       req
         .decode[Fishnet.PostMove]: move =>
-          move.move.bestmove
-            .fold(executor.invalidate(id, move.fishnet.apikey))(executor.move(id, move.fishnet.apikey, _))
+          executor.move(id, move.fishnet.apikey, move.move.bestmove)
             >> acquire(move.fishnet.apikey)
 
   def acquire(key: ClientKey): IO[Response[IO]] =

--- a/app/src/main/scala/http/FishnetRoutes.scala
+++ b/app/src/main/scala/http/FishnetRoutes.scala
@@ -27,8 +27,6 @@ final class FishnetRoutes(executor: Executor) extends Http4sDsl[IO]:
           move.move.bestmove
             .fold(executor.invalidate(id, move.fishnet.apikey))(executor.move(id, move.fishnet.apikey, _))
             >> acquire(move.fishnet.apikey)
-      // executor.move(id, move.fishnet.apikey, move.move.bestmove)
-      //   >> acquire(move.fishnet.apikey)
 
   def acquire(key: ClientKey): IO[Response[IO]] =
     executor

--- a/app/src/main/scala/http/FishnetRoutes.scala
+++ b/app/src/main/scala/http/FishnetRoutes.scala
@@ -24,8 +24,11 @@ final class FishnetRoutes(executor: Executor) extends Http4sDsl[IO]:
     case req @ POST -> Root / "move" / WorkIdVar(id) =>
       req
         .decode[Fishnet.PostMove]: move =>
-          executor.move(id, move.fishnet.apikey, move.move.bestmove)
+          move.move.bestmove
+            .fold(executor.invalidate(id, move.fishnet.apikey))(executor.move(id, move.fishnet.apikey, _))
             >> acquire(move.fishnet.apikey)
+      // executor.move(id, move.fishnet.apikey, move.move.bestmove)
+      //   >> acquire(move.fishnet.apikey)
 
   def acquire(key: ClientKey): IO[Response[IO]] =
     executor

--- a/app/src/main/scala/model.scala
+++ b/app/src/main/scala/model.scala
@@ -53,7 +53,7 @@ object Fishnet:
   case class Acquire(fishnet: Fishnet) derives Codec.AsObject
   case class Fishnet(version: String, apikey: ClientKey) derives Codec.AsObject
   case class PostMove(fishnet: Fishnet, move: Move) derives Codec.AsObject
-  case class Move(bestmove: BestMove)
+  case class Move(bestmove: Option[BestMove]) derives Codec.AsObject
 
   case class Work(id: WorkId, level: Int, clock: Option[Lila.Clock], `type`: String = "move")
       derives Encoder.AsObject

--- a/app/src/test/scala/CleaningJobTest.scala
+++ b/app/src/test/scala/CleaningJobTest.scala
@@ -26,9 +26,7 @@ object CleaningJobTest extends SimpleIOSuite:
 
   def createExcutor(ref: Ref[IO, Int]): Executor =
     new Executor:
-      def acquire(accquire: ClientKey)                                = IO.none
-      def move(workId: WorkId, fishnetKey: ClientKey, move: BestMove) = IO.unit
-      def add(work: Lila.Request)                                     = IO.unit
-      def clean(before: Instant)                                      = ref.update(_ + 1)
-      def onStart                                                     = IO.unit
-      def onStop                                                      = IO.unit
+      def acquire(accquire: ClientKey)                                 = IO.none
+      def move(workId: WorkId, key: ClientKey, move: Option[BestMove]) = IO.unit
+      def add(work: Lila.Request)                                      = IO.unit
+      def clean(before: Instant)                                       = ref.update(_ + 1)

--- a/app/src/test/scala/ExecutorTest.scala
+++ b/app/src/test/scala/ExecutorTest.scala
@@ -114,6 +114,17 @@ object ExecutorTest extends SimpleIOSuite:
       acquired = acquiredOption.get
     yield expect.same(acquired.request, request)
 
+  test("post null move should remove the task"):
+    for
+      ref      <- emptyMovesRef
+      executor <- createExecutor(ref)(ExecutorConfig(2))
+      _        <- executor.add(request)
+      acquired <- executor.acquire(key)
+      _        <- executor.invalidate(acquired.get.id, key)
+      response <- ref.get.map(_.headOption)
+      acquired <- executor.acquire(key)
+    yield assert(acquired.isEmpty && response.isEmpty)
+
   test("should not give up after 2 tries"):
     for
       executor <- createExecutor(ExecutorConfig(2))

--- a/app/src/test/scala/IntegrationTest.scala
+++ b/app/src/test/scala/IntegrationTest.scala
@@ -54,7 +54,7 @@ object IntegrationTest extends IOSuite:
     val fishnet               = Fishnet("2.7.2", ClientKey("secret-key"))
     val fishnetAcquireRequest = Acquire(fishnet)
     val bestMoves             = List("e7e6", "d7d5", "d8d6")
-    val postMoves             = bestMoves.map(m => PostMove(fishnet, Move(BestMove(m))))
+    val postMoves             = bestMoves.map(m => PostMove(fishnet, Move(BestMove(m).some)))
 
     val gameId = "CPzkP0tq"
     val lilaRequests =

--- a/app/src/test/scala/http/FishnetRoutesTest.scala
+++ b/app/src/test/scala/http/FishnetRoutesTest.scala
@@ -31,6 +31,16 @@ object FishnetRoutesTest extends SimpleIOSuite:
     }
   }"""
 
+  val postNullMoveRequestBody = json"""{
+    "fishnet": {
+      "version": "1.0.0",
+      "apikey": "apikey"
+    },
+    "move": {
+      "bestmove": null
+    }
+  }"""
+
   val workResponse: Json = json"""{
     "work": {
       "id": "workid",
@@ -69,10 +79,16 @@ object FishnetRoutesTest extends SimpleIOSuite:
     val req      = Request[IO](Method.POST, uri"/fishnet/acquire").withEntity(acqurieRequestBody)
     exepectHttpBodyAndStatus(routes, req)(expectedBody = workResponse, expectedStatus = Status.Ok)
 
-  test("POST /fishnet/move should also return work response"):
+  test("POST /fishnet/move should return work response"):
     val executor = createExecutor()
     val routes   = createRoutes(executor)
     val req      = Request[IO](Method.POST, uri"/fishnet/move/workid").withEntity(postMoveRequestBody)
+    exepectHttpBodyAndStatus(routes, req)(expectedBody = workResponse, expectedStatus = Status.Ok)
+
+  test("POST /fishnet/move with null move should also return work response"):
+    val executor = createExecutor()
+    val routes   = createRoutes(executor)
+    val req      = Request[IO](Method.POST, uri"/fishnet/move/workid").withEntity(postNullMoveRequestBody)
     exepectHttpBodyAndStatus(routes, req)(expectedBody = workResponse, expectedStatus = Status.Ok)
 
   def exepectHttpBodyAndStatus(routes: HttpRoutes[IO], req: Request[IO])(

--- a/app/src/test/scala/http/FishnetRoutesTest.scala
+++ b/app/src/test/scala/http/FishnetRoutesTest.scala
@@ -110,9 +110,8 @@ object FishnetRoutesTest extends SimpleIOSuite:
   def createExecutor(): Executor =
     new Executor:
       def acquire(key: ClientKey) = IO.pure(task.some)
-      def move(id: WorkId, key: ClientKey, move: BestMove) =
+      def move(id: WorkId, key: ClientKey, move: Option[BestMove]) =
         if id == task.id then IO.unit
         else IO.raiseError(new Exception("invalid work id"))
-      def invalidate(workId: WorkId, fishnetKey: ClientKey) = IO.unit
-      def add(request: Lila.Request)                        = IO.unit
-      def clean(before: Instant)                            = IO.unit
+      def add(request: Lila.Request) = IO.unit
+      def clean(before: Instant)     = IO.unit

--- a/app/src/test/scala/http/FishnetRoutesTest.scala
+++ b/app/src/test/scala/http/FishnetRoutesTest.scala
@@ -110,10 +110,9 @@ object FishnetRoutesTest extends SimpleIOSuite:
   def createExecutor(): Executor =
     new Executor:
       def acquire(key: ClientKey) = IO.pure(task.some)
-      def move(id: WorkId, key: ClientKey, move: BestMove): IO[Unit] =
+      def move(id: WorkId, key: ClientKey, move: BestMove) =
         if id == task.id then IO.unit
         else IO.raiseError(new Exception("invalid work id"))
-      def add(request: Lila.Request): IO[Unit] = IO.unit
-      def clean(before: Instant)               = IO.unit
-      def onStart                              = IO.unit
-      def onStop                               = IO.unit
+      def invalidate(workId: WorkId, fishnetKey: ClientKey) = IO.unit
+      def add(request: Lila.Request)                        = IO.unit
+      def clean(before: Instant)                            = IO.unit


### PR DESCRIPTION
If fishnet clients send null as `bestmove` that mean the assigned task is invalid or the game is already finished. So, We should just remove it from the queue instead push it back to the queue.