### PR TITLE
Add function to config server timeout

### DIFF
--- a/app/src/main/scala/AppConfig.scala
+++ b/app/src/main/scala/AppConfig.scala
@@ -26,13 +26,14 @@ case class AppConfig(
     repository: RepositoryConfig
 )
 
-case class HttpServerConfig(host: Host, port: Port, apiLogger: Boolean)
+case class HttpServerConfig(host: Host, port: Port, apiLogger: Boolean, shutdownTimeout: Int)
 
 object HttpServerConfig:
-  def host   = env("HTTP_HOST").or(prop("http.host")).as[Host].default(ip"0.0.0.0")
-  def port   = env("HTTP_PORT").or(prop("http.port")).as[Port].default(port"9665")
-  def logger = env("HTTP_API_LOGGER").or(prop("http.api.logger")).as[Boolean].default(false)
-  def config = (host, port, logger).parMapN(HttpServerConfig.apply)
+  def host            = env("HTTP_HOST").or(prop("http.host")).as[Host].default(ip"0.0.0.0")
+  def port            = env("HTTP_PORT").or(prop("http.port")).as[Port].default(port"9665")
+  def logger          = env("HTTP_API_LOGGER").or(prop("http.api.logger")).as[Boolean].default(false)
+  def shutdownTimeout = env("HTTP_SHUTDOWN_TIMEOUT").or(prop("http.shutdown.timeout")).as[Int].default(30)
+  def config          = (host, port, logger, shutdownTimeout).parMapN(HttpServerConfig.apply)
 
 case class RedisConfig(host: Host, port: Port)
 

--- a/app/src/main/scala/http/MkHttpServer.scala
+++ b/app/src/main/scala/http/MkHttpServer.scala
@@ -7,6 +7,8 @@ import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server
 import org.typelevel.log4cats.Logger
 
+import scala.concurrent.duration.*
+
 trait MkHttpServer:
   def newEmber(cfg: HttpServerConfig, httpApp: HttpApp[IO]): Resource[IO, Server]
 
@@ -21,6 +23,7 @@ object MkHttpServer:
       .withHost(cfg.host)
       .withPort(cfg.port)
       .withHttpApp(httpApp)
+      .withShutdownTimeout(cfg.shutdownTimeout.seconds)
       .build
       .evalTap(showBanner)
 

--- a/app/src/test/scala/IntegrationTest.scala
+++ b/app/src/test/scala/IntegrationTest.scala
@@ -36,7 +36,7 @@ object IntegrationTest extends IOSuite:
     yield res
 
   def testAppConfig(redis: RedisConfig) = AppConfig(
-    server = HttpServerConfig(ip"0.0.0.0", port"9999", apiLogger = false),
+    server = HttpServerConfig(ip"0.0.0.0", port"9999", apiLogger = false, shutdownTimeout = 30),
     redis = redis,
     kamon = KamonConfig(enabled = false),
     executor = ExecutorConfig(maxSize = 300),


### PR DESCRIPTION
Http4s by default is set to wait for 30 sec after receive shutdown signal to allow for inflight requests to give responses before being killed of. But this seems excessive for us. This commit help us to config the timeout.