### PR TITLE
Refactor BestMove from String to Uci

### DIFF
--- a/app/src/main/scala/model.scala
+++ b/app/src/main/scala/model.scala
@@ -15,14 +15,12 @@ object ClientKey:
   given Decoder[ClientKey]                    = decodeString
   extension (ck: ClientKey) def value: String = ck
 
-opaque type BestMove = String
+opaque type BestMove = Uci
 object BestMove:
-  def apply(value: String): BestMove = value
-  given Encoder[BestMove]            = encodeString
-  given Decoder[BestMove]            = decodeString
-  extension (bm: BestMove)
-    def value: String    = bm
-    def uci: Option[Uci] = Uci(bm)
+  def apply(value: Uci): BestMove         = value
+  given Encoder[BestMove]                 = encodeString.contramap(_.uci)
+  given Decoder[BestMove]                 = decodeString.emap(Uci.apply(_).toRight("Invalid Uci"))
+  extension (bm: BestMove) def value: Uci = bm
 
 opaque type WorkId = String
 object WorkId:

--- a/app/src/test/scala/IntegrationTest.scala
+++ b/app/src/test/scala/IntegrationTest.scala
@@ -2,6 +2,7 @@ package lila.fishnet
 
 import cats.effect.{ IO, Ref, Resource }
 import cats.syntax.all.*
+import chess.format.Uci
 import com.comcast.ip4s.*
 import com.dimafeng.testcontainers.GenericContainer
 import io.chrisdavenport.rediculous.RedisPubSub
@@ -53,7 +54,7 @@ object IntegrationTest extends IOSuite:
   test("let's play a game"): res =>
     val fishnet               = Fishnet("2.7.2", ClientKey("secret-key"))
     val fishnetAcquireRequest = Acquire(fishnet)
-    val bestMoves             = List("e7e6", "d7d5", "d8d6")
+    val bestMoves             = List("e7e6", "d7d5", "d8d6").traverse(Uci.apply).get
     val postMoves             = bestMoves.map(m => PostMove(fishnet, Move(BestMove(m).some)))
 
     val gameId = "CPzkP0tq"


### PR DESCRIPTION
We should never receive invalid Uci from fishnet clients. So, it'd be more efficient to invalidate bestmove when deserialize requests from fishnet clients. This helps simplify logics of Executor as well as remove some extra tests.