### PR TITLE
Set universal target ouput static

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ versionScheme     := Some("early-semver")
 run / fork        := true
 semanticdbEnabled := true // for scalafix
 
+Universal / target := baseDirectory.value / "target" / "universal"
+
 val dockerSettings = Seq(
   dockerBaseImage       := "eclipse-temurin:25-jdk-noble",
   dockerUpdateLatest    := true,


### PR DESCRIPTION
This help output of staging task are the same as sbt-1. Which in turns
help deploy scripts works. Otherwise the target output will be dynamic,
a.k.a it'll include scala version in the path.
